### PR TITLE
Releasing connections on allowed empty results when not in a transaction

### DIFF
--- a/lib/methods/_queryCallback.js
+++ b/lib/methods/_queryCallback.js
@@ -37,6 +37,10 @@ const _queryCallback = (deferred, connection, transaction, singleReturnItem, all
     if (isNilOrEmpty(data)) {
 
       if (allowEmptyResponse) {
+        if (!transaction) {
+          connection.release();
+        }
+
         deferred.resolve(singleReturnItem ? undefined : [])
       } else {
         connection.release();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"            : "alien-node-mysql-utils",
-  "version"         : "0.5.4",
+  "version"         : "0.5.5",
   "description"     : "Helper functions for MySQL on NodeJS",
   "main"            : "lib/DB.js",
   "dependencies"    : {

--- a/spec/_queryCallbackSpec.js
+++ b/spec/_queryCallbackSpec.js
@@ -172,6 +172,7 @@ describe('_queryCallback', () => {
 
     deferred.promise.then(res => {
       expect(res).toEqual([]);
+      expect(FAKE_CONNECTION.release).toHaveBeenCalled();
       done();
     });
 
@@ -183,6 +184,26 @@ describe('_queryCallback', () => {
       ALLOW_EMPTY_RESPONSE_TRUE
     )(null, []);
   });
+
+  it('invokes a transaction, querySafe() callback with no errors on an empty response', done => {
+
+    const deferred = Q.defer();
+
+    deferred.promise.then(res => {
+      expect(res).toEqual([]);
+      expect(FAKE_CONNECTION.release).not.toHaveBeenCalled();
+      done();
+    });
+
+    _queryCallback(
+      deferred,
+      FAKE_CONNECTION,
+      IS_TRANSACTION_TRUE,
+      SINGLE_RETURN_ITEM_FALSE,
+      ALLOW_EMPTY_RESPONSE_TRUE
+    )(null, []);
+  });
+
 
   it('invokes a non-transaction, querySafe() callback with no errors on a single-item array', done => {
 


### PR DESCRIPTION
Subject pretty much sums up what this pull request is about - we were seeing apps and tests that talk to mysql through alien-node-mysql-utils hang after a point & were able to mediate the issue by increasing the number of connections.  With this change applied we are able to reduce the number of connections and do not see the hanging behavior (basically just copied the "if not in a transaction release connection" logic from the non-empty result else block).  Wasn't sure if bumping the version would be appropriate in this PR, but figured it wouldn't hurt to include as well.